### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ sudo apt install -y subversion g++ zlib1g-dev build-essential git python python3
 
 sudo apt install -y libfuse-dev libncurses5-dev gawk gettext unzip file libssl-dev wget asciidoc binutils g++-multilib antlr3 gperf swig rsync
 
-sudo apt install -y libelf-dev ecj fastjar java-propose-classpath bzip2 patch lib32gcc1 libc6-dev-i386 libglib2.0-dev xmlto qemu-utils upx curl npm
+sudo apt install -y libelf-dev ecj fastjar java-propose-classpath bzip2 patch lib32gcc-s1 libc6-dev-i386 libglib2.0-dev xmlto qemu-utils upx-ucl curl npm
 
 
 **2 mkdir openwrt**


### PR DESCRIPTION

Source text
Note, selecting 'upx-ucl' instead of 'upx'
Package lib32gcc1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  lib32gcc-s1